### PR TITLE
fix: do not follow redirect in fallback policy

### DIFF
--- a/src/launch.ts
+++ b/src/launch.ts
@@ -40,6 +40,7 @@ export function launch() {
       headers: request.headers as Record<string, string>,
       method: 'GET',
       baseURL: 'https://backend.raycast.com', // This is the only difference
+      redirect: 'manual',
     }).catch((reason) => {
       consola.error(`[GET] ${subUrl} <-- 托底策略 <-x- Backend Response Error`)
       consola.error(reason)


### PR DESCRIPTION
### Description

Do not follow redirect in the fallback request handler, or else this will cause the extension installation not to work.

### Linked Issues

None

### Additional context

None
