### PR TITLE
increase node old space for rollup build 

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "build": "unbuild",
-    "build:rollup": "rollup -c",
+    "build:rollup": "NODE_OPTIONS=--max-old-space-size=4096 rollup -c",
     "bundle": "sh scripts/single-application.sh",
     "dev": "pnpm start:dev",
     "lint": "eslint .",


### PR DESCRIPTION
### Description

In low memory machine, the `build:rollup` may result in an `Allocation failed - JavaScript heap out of memory` error.

This PR increases the node max-old-space-size to fix it.

### Linked Issues

None

### Additional context

https://stackoverflow.com/questions/47444594/rollupjs-javascript-heap-out-of-memory
