### PR TITLE
Support change OpenAI Translate model

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -82,6 +82,10 @@ default = "deeplx"
 # the default model written in the code will be used
 # Default: openai
 default = "openai"
+# The model used by the AI service
+# (only effective for openai)
+# Default: gpt-3.5-turbo
+model = "gpt-3.5-turbo"
 
 [Translate.LibreTranslate]
 base_url = "https://libretranslate.com"

--- a/src/features/ai/generate/openai.ts
+++ b/src/features/ai/generate/openai.ts
@@ -5,7 +5,7 @@ import type { AIGenerateContent } from '../../../types/internal/ai-generate-cont
 export async function OpenaiGenerateContent(prompt: {
   role: string
   content: string
-}[], msg?: string): Promise<AIGenerateContent> {
+}[], model?: string): Promise<AIGenerateContent> {
   const aiConfig = getConfig('ai')
   const openaiConfig = getConfig('ai')?.openai
   const openai = new OpenAI({
@@ -20,12 +20,7 @@ export async function OpenaiGenerateContent(prompt: {
       content: m.content,
     })
   }
-  if (msg) {
-    message.push({
-      role: 'system',
-      content: msg,
-    })
-  }
+
   const result = await openai.chat.completions.create({
     stream: false,
     messages: message as any,
@@ -33,7 +28,7 @@ export async function OpenaiGenerateContent(prompt: {
     stop: null,
     n: 1,
     max_tokens: openaiConfig?.maxTokens || aiConfig?.maxTokens,
-    model: openaiConfig?.default || 'gpt-3.5-turbo',
+    model: model || 'gpt-3.5-turbo',
   }).catch((err) => {
     throw new Error(`[AI] OpenAI Chat Completions Failed: ${err}`)
   })

--- a/src/features/translations/ai.ts
+++ b/src/features/translations/ai.ts
@@ -26,15 +26,15 @@ export async function TranslateWithAI(request: FastifyRequest): Promise<Translat
     case 'gemini':
       content = await GeminiGenerateContent(prompts)
       break
-    case 'openai':
-      content = await OpenaiGenerateContent(prompts)
-      break
     case 'copilot':
       content = await CopilotGenerateContent(prompts)
       break
-    default:
-      content = await OpenaiGenerateContent(prompts)
+    case 'openai':
+    default: {
+      const model = getConfig('translate')?.ai?.model
+      content = await OpenaiGenerateContent(prompts, model)
       break
+    }
   }
 
   const res = {

--- a/src/types/config/translate.ts
+++ b/src/types/config/translate.ts
@@ -10,6 +10,7 @@ export interface DeepLXTranslateServiceConfig {
 }
 export interface AITranslateServiceConfig {
   default?: string
+  model?: string
 }
 export interface LibreTranslateServiceConfig {
   baseUrl?: string


### PR DESCRIPTION

### Description

Since `openaiConfig.default` represents the model id, it shouldn't be used as the name of the translation model.

### Linked Issues

None

### Additional context

This PR introduces a new config `Translate.AI.model` (defaults to `gpt-3.5-turbo`)
