### PR TITLE
fix(routes/ai/model): default openai model may not work

### DIFF
--- a/src/routes/ai/model.ts
+++ b/src/routes/ai/model.ts
@@ -31,11 +31,13 @@ function getDefaultInOpenAIModels() {
   if (openaiConfig?.default) {
     const model = openaiConfig.models?.[openaiConfig.default]
     if (model) {
+      const id = model.id || openaiConfig.default
+
       default_model = {
-        chat: model.id!,
-        quick_ai: model.id!,
-        commands: model.id!,
-        api: model.id!,
+        chat: id,
+        quick_ai: id,
+        commands: id,
+        api: id,
       }
     }
   }

--- a/src/utils/env.util.ts
+++ b/src/utils/env.util.ts
@@ -14,8 +14,8 @@ import { matchKeyInObject, toCamelCaseInObject, tolowerCaseInObject, transformTo
  * It may be configured to a non-existent model, in this case, it needs to be removed
  */
 function checkOpenAIDefaultModelConfig(env: Config) {
-  if (env.ai?.openai?.default?.toLowerCase() && !(env.ai.openai.models as any)[env.ai.openai.default?.toLowerCase()]) {
-    consola.warn(`The default AI model [${env.ai.openai.default?.toLowerCase()}] is not available, it will be removed from the config`)
+  if (env.ai?.openai?.default && !(env.ai.openai.models as any)[env.ai.openai.default]) {
+    consola.warn(`The default AI model [${env.ai.openai.default}] is not available (available models: [${Object.keys(env.ai.openai.models || {}).join(', ')}]), it will be removed from the config`)
     // delete env.ai.openai.default
     if (env.ai.openai.default)
       delete env.ai.openai.default


### PR DESCRIPTION

### Description

The current openai default model config may not work.

### Linked Issues

None

### Additional context

This PR also improves `checkOpenAIDefaultModelConfig`.
