### PR TITLE
do not throw error if no capabilities set

### DIFF
--- a/src/routes/ai/models.ts
+++ b/src/routes/ai/models.ts
@@ -13,7 +13,7 @@ function generateRaycastAIServiceProviders() {
           [key: string]: string | undefined
         } = {}
 
-        for (const [key, val] of Object.entries(value.capabilities))
+        for (const [key, val] of Object.entries(value.capabilities || {}))
           capabilities[key] = val ? 'full' : undefined
 
         return ({


### PR DESCRIPTION
After upgrading to v0.4.0-beta.0, there will be an error "Cannot convert undefined or null to object" without modifying config file.

This PR fixes this.